### PR TITLE
fix: remove DisallowUnknownFields from mempool transaction models

### DIFF
--- a/stacks/models/model_abstract_transaction_all_of_tx_result.go
+++ b/stacks/models/model_abstract_transaction_all_of_tx_result.go
@@ -129,7 +129,6 @@ func (o *AbstractTransactionAllOfTxResult) UnmarshalJSON(data []byte) (err error
 	varAbstractTransactionAllOfTxResult := _AbstractTransactionAllOfTxResult{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAbstractTransactionAllOfTxResult)
 
 	if err != nil {

--- a/stacks/models/model_account_data_response.go
+++ b/stacks/models/model_account_data_response.go
@@ -239,7 +239,6 @@ func (o *AccountDataResponse) UnmarshalJSON(data []byte) (err error) {
 	varAccountDataResponse := _AccountDataResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAccountDataResponse)
 
 	if err != nil {

--- a/stacks/models/model_address_assets_list_response.go
+++ b/stacks/models/model_address_assets_list_response.go
@@ -183,7 +183,6 @@ func (o *AddressAssetsListResponse) UnmarshalJSON(data []byte) (err error) {
 	varAddressAssetsListResponse := _AddressAssetsListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressAssetsListResponse)
 
 	if err != nil {

--- a/stacks/models/model_address_balance_response.go
+++ b/stacks/models/model_address_balance_response.go
@@ -191,7 +191,6 @@ func (o *AddressBalanceResponse) UnmarshalJSON(data []byte) (err error) {
 	varAddressBalanceResponse := _AddressBalanceResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressBalanceResponse)
 
 	if err != nil {

--- a/stacks/models/model_address_nonces.go
+++ b/stacks/models/model_address_nonces.go
@@ -228,7 +228,6 @@ func (o *AddressNonces) UnmarshalJSON(data []byte) (err error) {
 	varAddressNonces := _AddressNonces{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressNonces)
 
 	if err != nil {

--- a/stacks/models/model_address_search_result.go
+++ b/stacks/models/model_address_search_result.go
@@ -130,7 +130,6 @@ func (o *AddressSearchResult) UnmarshalJSON(data []byte) (err error) {
 	varAddressSearchResult := _AddressSearchResult{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressSearchResult)
 
 	if err != nil {

--- a/stacks/models/model_address_search_result_result.go
+++ b/stacks/models/model_address_search_result_result.go
@@ -164,7 +164,6 @@ func (o *AddressSearchResultResult) UnmarshalJSON(data []byte) (err error) {
 	varAddressSearchResultResult := _AddressSearchResultResult{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressSearchResultResult)
 
 	if err != nil {

--- a/stacks/models/model_address_stx_balance_response.go
+++ b/stacks/models/model_address_stx_balance_response.go
@@ -392,7 +392,6 @@ func (o *AddressStxBalanceResponse) UnmarshalJSON(data []byte) (err error) {
 	varAddressStxBalanceResponse := _AddressStxBalanceResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressStxBalanceResponse)
 
 	if err != nil {

--- a/stacks/models/model_address_stx_inbound_list_response.go
+++ b/stacks/models/model_address_stx_inbound_list_response.go
@@ -183,7 +183,6 @@ func (o *AddressStxInboundListResponse) UnmarshalJSON(data []byte) (err error) {
 	varAddressStxInboundListResponse := _AddressStxInboundListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressStxInboundListResponse)
 
 	if err != nil {

--- a/stacks/models/model_address_token_offering_locked.go
+++ b/stacks/models/model_address_token_offering_locked.go
@@ -157,7 +157,6 @@ func (o *AddressTokenOfferingLocked) UnmarshalJSON(data []byte) (err error) {
 	varAddressTokenOfferingLocked := _AddressTokenOfferingLocked{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTokenOfferingLocked)
 
 	if err != nil {

--- a/stacks/models/model_address_transaction.go
+++ b/stacks/models/model_address_transaction.go
@@ -193,7 +193,6 @@ func (o *AddressTransaction) UnmarshalJSON(data []byte) (err error) {
 	varAddressTransaction := _AddressTransaction{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransaction)
 
 	if err != nil {

--- a/stacks/models/model_address_transaction_event_any_of.go
+++ b/stacks/models/model_address_transaction_event_any_of.go
@@ -155,7 +155,6 @@ func (o *AddressTransactionEventAnyOf) UnmarshalJSON(data []byte) (err error) {
 	varAddressTransactionEventAnyOf := _AddressTransactionEventAnyOf{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransactionEventAnyOf)
 
 	if err != nil {

--- a/stacks/models/model_address_transaction_event_any_of_1.go
+++ b/stacks/models/model_address_transaction_event_any_of_1.go
@@ -155,7 +155,6 @@ func (o *AddressTransactionEventAnyOf1) UnmarshalJSON(data []byte) (err error) {
 	varAddressTransactionEventAnyOf1 := _AddressTransactionEventAnyOf1{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransactionEventAnyOf1)
 
 	if err != nil {

--- a/stacks/models/model_address_transaction_event_any_of_1_data.go
+++ b/stacks/models/model_address_transaction_event_any_of_1_data.go
@@ -231,7 +231,6 @@ func (o *AddressTransactionEventAnyOf1Data) UnmarshalJSON(data []byte) (err erro
 	varAddressTransactionEventAnyOf1Data := _AddressTransactionEventAnyOf1Data{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransactionEventAnyOf1Data)
 
 	if err != nil {

--- a/stacks/models/model_address_transaction_event_any_of_2.go
+++ b/stacks/models/model_address_transaction_event_any_of_2.go
@@ -155,7 +155,6 @@ func (o *AddressTransactionEventAnyOf2) UnmarshalJSON(data []byte) (err error) {
 	varAddressTransactionEventAnyOf2 := _AddressTransactionEventAnyOf2{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransactionEventAnyOf2)
 
 	if err != nil {

--- a/stacks/models/model_address_transaction_event_any_of_2_data.go
+++ b/stacks/models/model_address_transaction_event_any_of_2_data.go
@@ -230,7 +230,6 @@ func (o *AddressTransactionEventAnyOf2Data) UnmarshalJSON(data []byte) (err erro
 	varAddressTransactionEventAnyOf2Data := _AddressTransactionEventAnyOf2Data{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransactionEventAnyOf2Data)
 
 	if err != nil {

--- a/stacks/models/model_address_transaction_event_any_of_2_data_value.go
+++ b/stacks/models/model_address_transaction_event_any_of_2_data_value.go
@@ -127,7 +127,6 @@ func (o *AddressTransactionEventAnyOf2DataValue) UnmarshalJSON(data []byte) (err
 	varAddressTransactionEventAnyOf2DataValue := _AddressTransactionEventAnyOf2DataValue{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransactionEventAnyOf2DataValue)
 
 	if err != nil {

--- a/stacks/models/model_address_transaction_event_any_of_data.go
+++ b/stacks/models/model_address_transaction_event_any_of_data.go
@@ -202,7 +202,6 @@ func (o *AddressTransactionEventAnyOfData) UnmarshalJSON(data []byte) (err error
 	varAddressTransactionEventAnyOfData := _AddressTransactionEventAnyOfData{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransactionEventAnyOfData)
 
 	if err != nil {

--- a/stacks/models/model_address_transaction_event_list_response.go
+++ b/stacks/models/model_address_transaction_event_list_response.go
@@ -183,7 +183,6 @@ func (o *AddressTransactionEventListResponse) UnmarshalJSON(data []byte) (err er
 	varAddressTransactionEventListResponse := _AddressTransactionEventListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransactionEventListResponse)
 
 	if err != nil {

--- a/stacks/models/model_address_transaction_events.go
+++ b/stacks/models/model_address_transaction_events.go
@@ -155,7 +155,6 @@ func (o *AddressTransactionEvents) UnmarshalJSON(data []byte) (err error) {
 	varAddressTransactionEvents := _AddressTransactionEvents{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransactionEvents)
 
 	if err != nil {

--- a/stacks/models/model_address_transaction_events_stx.go
+++ b/stacks/models/model_address_transaction_events_stx.go
@@ -155,7 +155,6 @@ func (o *AddressTransactionEventsStx) UnmarshalJSON(data []byte) (err error) {
 	varAddressTransactionEventsStx := _AddressTransactionEventsStx{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransactionEventsStx)
 
 	if err != nil {

--- a/stacks/models/model_address_transaction_with_transfers.go
+++ b/stacks/models/model_address_transaction_with_transfers.go
@@ -257,7 +257,6 @@ func (o *AddressTransactionWithTransfers) UnmarshalJSON(data []byte) (err error)
 	varAddressTransactionWithTransfers := _AddressTransactionWithTransfers{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransactionWithTransfers)
 
 	if err != nil {

--- a/stacks/models/model_address_transaction_with_transfers_ft_transfers_inner.go
+++ b/stacks/models/model_address_transaction_with_transfers_ft_transfers_inner.go
@@ -203,7 +203,6 @@ func (o *AddressTransactionWithTransfersFtTransfersInner) UnmarshalJSON(data []b
 	varAddressTransactionWithTransfersFtTransfersInner := _AddressTransactionWithTransfersFtTransfersInner{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransactionWithTransfersFtTransfersInner)
 
 	if err != nil {

--- a/stacks/models/model_address_transaction_with_transfers_nft_transfers_inner.go
+++ b/stacks/models/model_address_transaction_with_transfers_nft_transfers_inner.go
@@ -202,7 +202,6 @@ func (o *AddressTransactionWithTransfersNftTransfersInner) UnmarshalJSON(data []
 	varAddressTransactionWithTransfersNftTransfersInner := _AddressTransactionWithTransfersNftTransfersInner{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransactionWithTransfersNftTransfersInner)
 
 	if err != nil {

--- a/stacks/models/model_address_transaction_with_transfers_stx_transfers_inner.go
+++ b/stacks/models/model_address_transaction_with_transfers_stx_transfers_inner.go
@@ -174,7 +174,6 @@ func (o *AddressTransactionWithTransfersStxTransfersInner) UnmarshalJSON(data []
 	varAddressTransactionWithTransfersStxTransfersInner := _AddressTransactionWithTransfersStxTransfersInner{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransactionWithTransfersStxTransfersInner)
 
 	if err != nil {

--- a/stacks/models/model_address_transactions_list_response.go
+++ b/stacks/models/model_address_transactions_list_response.go
@@ -183,7 +183,6 @@ func (o *AddressTransactionsListResponse) UnmarshalJSON(data []byte) (err error)
 	varAddressTransactionsListResponse := _AddressTransactionsListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransactionsListResponse)
 
 	if err != nil {

--- a/stacks/models/model_address_transactions_v2_list_response.go
+++ b/stacks/models/model_address_transactions_v2_list_response.go
@@ -183,7 +183,6 @@ func (o *AddressTransactionsV2ListResponse) UnmarshalJSON(data []byte) (err erro
 	varAddressTransactionsV2ListResponse := _AddressTransactionsV2ListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransactionsV2ListResponse)
 
 	if err != nil {

--- a/stacks/models/model_address_transactions_with_transfers_list_response.go
+++ b/stacks/models/model_address_transactions_with_transfers_list_response.go
@@ -183,7 +183,6 @@ func (o *AddressTransactionsWithTransfersListResponse) UnmarshalJSON(data []byte
 	varAddressTransactionsWithTransfersListResponse := _AddressTransactionsWithTransfersListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressTransactionsWithTransfersListResponse)
 
 	if err != nil {

--- a/stacks/models/model_address_unlock_schedule.go
+++ b/stacks/models/model_address_unlock_schedule.go
@@ -128,7 +128,6 @@ func (o *AddressUnlockSchedule) UnmarshalJSON(data []byte) (err error) {
 	varAddressUnlockSchedule := _AddressUnlockSchedule{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAddressUnlockSchedule)
 
 	if err != nil {

--- a/stacks/models/model_average_block_times_response.go
+++ b/stacks/models/model_average_block_times_response.go
@@ -187,7 +187,6 @@ func (o *AverageBlockTimesResponse) UnmarshalJSON(data []byte) (err error) {
 	varAverageBlockTimesResponse := _AverageBlockTimesResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varAverageBlockTimesResponse)
 
 	if err != nil {

--- a/stacks/models/model_block.go
+++ b/stacks/models/model_block.go
@@ -738,7 +738,6 @@ func (o *Block) UnmarshalJSON(data []byte) (err error) {
 	varBlock := _Block{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBlock)
 
 	if err != nil {

--- a/stacks/models/model_block_list_response.go
+++ b/stacks/models/model_block_list_response.go
@@ -188,7 +188,6 @@ func (o *BlockListResponse) UnmarshalJSON(data []byte) (err error) {
 	varBlockListResponse := _BlockListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBlockListResponse)
 
 	if err != nil {

--- a/stacks/models/model_block_search_result.go
+++ b/stacks/models/model_block_search_result.go
@@ -130,7 +130,6 @@ func (o *BlockSearchResult) UnmarshalJSON(data []byte) (err error) {
 	varBlockSearchResult := _BlockSearchResult{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBlockSearchResult)
 
 	if err != nil {

--- a/stacks/models/model_block_search_result_result.go
+++ b/stacks/models/model_block_search_result_result.go
@@ -192,7 +192,6 @@ func (o *BlockSearchResultResult) UnmarshalJSON(data []byte) (err error) {
 	varBlockSearchResultResult := _BlockSearchResultResult{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBlockSearchResultResult)
 
 	if err != nil {

--- a/stacks/models/model_block_search_result_result_block_data.go
+++ b/stacks/models/model_block_search_result_result_block_data.go
@@ -213,7 +213,6 @@ func (o *BlockSearchResultResultBlockData) UnmarshalJSON(data []byte) (err error
 	varBlockSearchResultResultBlockData := _BlockSearchResultResultBlockData{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBlockSearchResultResultBlockData)
 
 	if err != nil {

--- a/stacks/models/model_bns_get_all_namespaces_response.go
+++ b/stacks/models/model_bns_get_all_namespaces_response.go
@@ -99,7 +99,6 @@ func (o *BnsGetAllNamespacesResponse) UnmarshalJSON(data []byte) (err error) {
 	varBnsGetAllNamespacesResponse := _BnsGetAllNamespacesResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBnsGetAllNamespacesResponse)
 
 	if err != nil {

--- a/stacks/models/model_bns_get_name_info_response.go
+++ b/stacks/models/model_bns_get_name_info_response.go
@@ -347,7 +347,6 @@ func (o *BnsGetNameInfoResponse) UnmarshalJSON(data []byte) (err error) {
 	varBnsGetNameInfoResponse := _BnsGetNameInfoResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBnsGetNameInfoResponse)
 
 	if err != nil {

--- a/stacks/models/model_bns_get_name_price_response.go
+++ b/stacks/models/model_bns_get_name_price_response.go
@@ -127,7 +127,6 @@ func (o *BnsGetNamePriceResponse) UnmarshalJSON(data []byte) (err error) {
 	varBnsGetNamePriceResponse := _BnsGetNamePriceResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBnsGetNamePriceResponse)
 
 	if err != nil {

--- a/stacks/models/model_bns_get_namespace_price_response.go
+++ b/stacks/models/model_bns_get_namespace_price_response.go
@@ -127,7 +127,6 @@ func (o *BnsGetNamespacePriceResponse) UnmarshalJSON(data []byte) (err error) {
 	varBnsGetNamespacePriceResponse := _BnsGetNamespacePriceResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBnsGetNamespacePriceResponse)
 
 	if err != nil {

--- a/stacks/models/model_bns_names_own_by_address_response.go
+++ b/stacks/models/model_bns_names_own_by_address_response.go
@@ -99,7 +99,6 @@ func (o *BnsNamesOwnByAddressResponse) UnmarshalJSON(data []byte) (err error) {
 	varBnsNamesOwnByAddressResponse := _BnsNamesOwnByAddressResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBnsNamesOwnByAddressResponse)
 
 	if err != nil {

--- a/stacks/models/model_burn_block.go
+++ b/stacks/models/model_burn_block.go
@@ -274,7 +274,6 @@ func (o *BurnBlock) UnmarshalJSON(data []byte) (err error) {
 	varBurnBlock := _BurnBlock{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBurnBlock)
 
 	if err != nil {

--- a/stacks/models/model_burn_block_list_response.go
+++ b/stacks/models/model_burn_block_list_response.go
@@ -188,7 +188,6 @@ func (o *BurnBlockListResponse) UnmarshalJSON(data []byte) (err error) {
 	varBurnBlockListResponse := _BurnBlockListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBurnBlockListResponse)
 
 	if err != nil {

--- a/stacks/models/model_burnchain_reward.go
+++ b/stacks/models/model_burnchain_reward.go
@@ -274,7 +274,6 @@ func (o *BurnchainReward) UnmarshalJSON(data []byte) (err error) {
 	varBurnchainReward := _BurnchainReward{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBurnchainReward)
 
 	if err != nil {

--- a/stacks/models/model_burnchain_reward_list_response.go
+++ b/stacks/models/model_burnchain_reward_list_response.go
@@ -159,7 +159,6 @@ func (o *BurnchainRewardListResponse) UnmarshalJSON(data []byte) (err error) {
 	varBurnchainRewardListResponse := _BurnchainRewardListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBurnchainRewardListResponse)
 
 	if err != nil {

--- a/stacks/models/model_burnchain_reward_slot_holder.go
+++ b/stacks/models/model_burnchain_reward_slot_holder.go
@@ -216,7 +216,6 @@ func (o *BurnchainRewardSlotHolder) UnmarshalJSON(data []byte) (err error) {
 	varBurnchainRewardSlotHolder := _BurnchainRewardSlotHolder{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBurnchainRewardSlotHolder)
 
 	if err != nil {

--- a/stacks/models/model_burnchain_reward_slot_holder_list_response.go
+++ b/stacks/models/model_burnchain_reward_slot_holder_list_response.go
@@ -188,7 +188,6 @@ func (o *BurnchainRewardSlotHolderListResponse) UnmarshalJSON(data []byte) (err 
 	varBurnchainRewardSlotHolderListResponse := _BurnchainRewardSlotHolderListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBurnchainRewardSlotHolderListResponse)
 
 	if err != nil {

--- a/stacks/models/model_burnchain_rewards_total.go
+++ b/stacks/models/model_burnchain_rewards_total.go
@@ -129,7 +129,6 @@ func (o *BurnchainRewardsTotal) UnmarshalJSON(data []byte) (err error) {
 	varBurnchainRewardsTotal := _BurnchainRewardsTotal{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varBurnchainRewardsTotal)
 
 	if err != nil {

--- a/stacks/models/model_chain_tip.go
+++ b/stacks/models/model_chain_tip.go
@@ -261,7 +261,6 @@ func (o *ChainTip) UnmarshalJSON(data []byte) (err error) {
 	varChainTip := _ChainTip{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varChainTip)
 
 	if err != nil {

--- a/stacks/models/model_coinbase_transaction.go
+++ b/stacks/models/model_coinbase_transaction.go
@@ -1155,7 +1155,6 @@ func (o *CoinbaseTransaction) UnmarshalJSON(data []byte) (err error) {
 	varCoinbaseTransaction := _CoinbaseTransaction{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varCoinbaseTransaction)
 
 	if err != nil {

--- a/stacks/models/model_coinbase_transaction_metadata_coinbase_payload.go
+++ b/stacks/models/model_coinbase_transaction_metadata_coinbase_payload.go
@@ -196,7 +196,6 @@ func (o *CoinbaseTransactionMetadataCoinbasePayload) UnmarshalJSON(data []byte) 
 	varCoinbaseTransactionMetadataCoinbasePayload := _CoinbaseTransactionMetadataCoinbasePayload{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varCoinbaseTransactionMetadataCoinbasePayload)
 
 	if err != nil {

--- a/stacks/models/model_contract_call_transaction.go
+++ b/stacks/models/model_contract_call_transaction.go
@@ -1155,7 +1155,6 @@ func (o *ContractCallTransaction) UnmarshalJSON(data []byte) (err error) {
 	varContractCallTransaction := _ContractCallTransaction{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varContractCallTransaction)
 
 	if err != nil {

--- a/stacks/models/model_contract_call_transaction_metadata_contract_call.go
+++ b/stacks/models/model_contract_call_transaction_metadata_contract_call.go
@@ -195,7 +195,6 @@ func (o *ContractCallTransactionMetadataContractCall) UnmarshalJSON(data []byte)
 	varContractCallTransactionMetadataContractCall := _ContractCallTransactionMetadataContractCall{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varContractCallTransactionMetadataContractCall)
 
 	if err != nil {

--- a/stacks/models/model_contract_call_transaction_metadata_contract_call_function_args_inner.go
+++ b/stacks/models/model_contract_call_transaction_metadata_contract_call_function_args_inner.go
@@ -180,7 +180,6 @@ func (o *ContractCallTransactionMetadataContractCallFunctionArgsInner) Unmarshal
 	varContractCallTransactionMetadataContractCallFunctionArgsInner := _ContractCallTransactionMetadataContractCallFunctionArgsInner{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varContractCallTransactionMetadataContractCallFunctionArgsInner)
 
 	if err != nil {

--- a/stacks/models/model_contract_interface_response.go
+++ b/stacks/models/model_contract_interface_response.go
@@ -216,7 +216,6 @@ func (o *ContractInterfaceResponse) UnmarshalJSON(data []byte) (err error) {
 	varContractInterfaceResponse := _ContractInterfaceResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varContractInterfaceResponse)
 
 	if err != nil {

--- a/stacks/models/model_contract_list_response.go
+++ b/stacks/models/model_contract_list_response.go
@@ -159,7 +159,6 @@ func (o *ContractListResponse) UnmarshalJSON(data []byte) (err error) {
 	varContractListResponse := _ContractListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varContractListResponse)
 
 	if err != nil {

--- a/stacks/models/model_contract_search_result.go
+++ b/stacks/models/model_contract_search_result.go
@@ -130,7 +130,6 @@ func (o *ContractSearchResult) UnmarshalJSON(data []byte) (err error) {
 	varContractSearchResult := _ContractSearchResult{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varContractSearchResult)
 
 	if err != nil {

--- a/stacks/models/model_contract_search_result_result.go
+++ b/stacks/models/model_contract_search_result_result.go
@@ -200,7 +200,6 @@ func (o *ContractSearchResultResult) UnmarshalJSON(data []byte) (err error) {
 	varContractSearchResultResult := _ContractSearchResultResult{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varContractSearchResultResult)
 
 	if err != nil {

--- a/stacks/models/model_contract_source_response.go
+++ b/stacks/models/model_contract_source_response.go
@@ -155,7 +155,6 @@ func (o *ContractSourceResponse) UnmarshalJSON(data []byte) (err error) {
 	varContractSourceResponse := _ContractSourceResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varContractSourceResponse)
 
 	if err != nil {

--- a/stacks/models/model_core_node_info_response.go
+++ b/stacks/models/model_core_node_info_response.go
@@ -448,7 +448,6 @@ func (o *CoreNodeInfoResponse) UnmarshalJSON(data []byte) (err error) {
 	varCoreNodeInfoResponse := _CoreNodeInfoResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varCoreNodeInfoResponse)
 
 	if err != nil {

--- a/stacks/models/model_core_node_pox_response.go
+++ b/stacks/models/model_core_node_pox_response.go
@@ -323,7 +323,6 @@ func (o *CoreNodePoxResponse) UnmarshalJSON(data []byte) (err error) {
 	varCoreNodePoxResponse := _CoreNodePoxResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varCoreNodePoxResponse)
 
 	if err != nil {

--- a/stacks/models/model_fee_rate.go
+++ b/stacks/models/model_fee_rate.go
@@ -99,7 +99,6 @@ func (o *FeeRate) UnmarshalJSON(data []byte) (err error) {
 	varFeeRate := _FeeRate{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varFeeRate)
 
 	if err != nil {

--- a/stacks/models/model_fee_rate_request.go
+++ b/stacks/models/model_fee_rate_request.go
@@ -100,7 +100,6 @@ func (o *FeeRateRequest) UnmarshalJSON(data []byte) (err error) {
 	varFeeRateRequest := _FeeRateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varFeeRateRequest)
 
 	if err != nil {

--- a/stacks/models/model_ft_balance.go
+++ b/stacks/models/model_ft_balance.go
@@ -155,7 +155,6 @@ func (o *FtBalance) UnmarshalJSON(data []byte) (err error) {
 	varFtBalance := _FtBalance{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varFtBalance)
 
 	if err != nil {

--- a/stacks/models/model_get_raw_transaction_result.go
+++ b/stacks/models/model_get_raw_transaction_result.go
@@ -100,7 +100,6 @@ func (o *GetRawTransactionResult) UnmarshalJSON(data []byte) (err error) {
 	varGetRawTransactionResult := _GetRawTransactionResult{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varGetRawTransactionResult)
 
 	if err != nil {

--- a/stacks/models/model_get_stx_supply_legacy_format_response.go
+++ b/stacks/models/model_get_stx_supply_legacy_format_response.go
@@ -245,7 +245,6 @@ func (o *GetStxSupplyLegacyFormatResponse) UnmarshalJSON(data []byte) (err error
 	varGetStxSupplyLegacyFormatResponse := _GetStxSupplyLegacyFormatResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varGetStxSupplyLegacyFormatResponse)
 
 	if err != nil {

--- a/stacks/models/model_get_stx_supply_response.go
+++ b/stacks/models/model_get_stx_supply_response.go
@@ -187,7 +187,6 @@ func (o *GetStxSupplyResponse) UnmarshalJSON(data []byte) (err error) {
 	varGetStxSupplyResponse := _GetStxSupplyResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varGetStxSupplyResponse)
 
 	if err != nil {

--- a/stacks/models/model_inbound_stx_transfer.go
+++ b/stacks/models/model_inbound_stx_transfer.go
@@ -274,7 +274,6 @@ func (o *InboundStxTransfer) UnmarshalJSON(data []byte) (err error) {
 	varInboundStxTransfer := _InboundStxTransfer{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varInboundStxTransfer)
 
 	if err != nil {

--- a/stacks/models/model_map_entry_response.go
+++ b/stacks/models/model_map_entry_response.go
@@ -137,7 +137,6 @@ func (o *MapEntryResponse) UnmarshalJSON(data []byte) (err error) {
 	varMapEntryResponse := _MapEntryResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMapEntryResponse)
 
 	if err != nil {

--- a/stacks/models/model_mempool_coinbase_transaction.go
+++ b/stacks/models/model_mempool_coinbase_transaction.go
@@ -517,7 +517,6 @@ func (o *MempoolCoinbaseTransaction) UnmarshalJSON(data []byte) (err error) {
 	varMempoolCoinbaseTransaction := _MempoolCoinbaseTransaction{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolCoinbaseTransaction)
 
 	if err != nil {

--- a/stacks/models/model_mempool_contract_call_transaction.go
+++ b/stacks/models/model_mempool_contract_call_transaction.go
@@ -517,7 +517,6 @@ func (o *MempoolContractCallTransaction) UnmarshalJSON(data []byte) (err error) 
 	varMempoolContractCallTransaction := _MempoolContractCallTransaction{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolContractCallTransaction)
 
 	if err != nil {

--- a/stacks/models/model_mempool_fee_priorities.go
+++ b/stacks/models/model_mempool_fee_priorities.go
@@ -207,7 +207,6 @@ func (o *MempoolFeePriorities) UnmarshalJSON(data []byte) (err error) {
 	varMempoolFeePriorities := _MempoolFeePriorities{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolFeePriorities)
 
 	if err != nil {

--- a/stacks/models/model_mempool_fee_priorities_all.go
+++ b/stacks/models/model_mempool_fee_priorities_all.go
@@ -183,7 +183,6 @@ func (o *MempoolFeePrioritiesAll) UnmarshalJSON(data []byte) (err error) {
 	varMempoolFeePrioritiesAll := _MempoolFeePrioritiesAll{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolFeePrioritiesAll)
 
 	if err != nil {

--- a/stacks/models/model_mempool_poison_microblock_transaction.go
+++ b/stacks/models/model_mempool_poison_microblock_transaction.go
@@ -517,7 +517,6 @@ func (o *MempoolPoisonMicroblockTransaction) UnmarshalJSON(data []byte) (err err
 	varMempoolPoisonMicroblockTransaction := _MempoolPoisonMicroblockTransaction{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolPoisonMicroblockTransaction)
 
 	if err != nil {

--- a/stacks/models/model_mempool_smart_contract_transaction.go
+++ b/stacks/models/model_mempool_smart_contract_transaction.go
@@ -517,7 +517,6 @@ func (o *MempoolSmartContractTransaction) UnmarshalJSON(data []byte) (err error)
 	varMempoolSmartContractTransaction := _MempoolSmartContractTransaction{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolSmartContractTransaction)
 
 	if err != nil {

--- a/stacks/models/model_mempool_tenure_change_transaction.go
+++ b/stacks/models/model_mempool_tenure_change_transaction.go
@@ -525,7 +525,6 @@ func (o *MempoolTenureChangeTransaction) UnmarshalJSON(data []byte) (err error) 
 	varMempoolTenureChangeTransaction := _MempoolTenureChangeTransaction{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolTenureChangeTransaction)
 
 	if err != nil {

--- a/stacks/models/model_mempool_token_transfer_transaction.go
+++ b/stacks/models/model_mempool_token_transfer_transaction.go
@@ -517,7 +517,6 @@ func (o *MempoolTokenTransferTransaction) UnmarshalJSON(data []byte) (err error)
 	varMempoolTokenTransferTransaction := _MempoolTokenTransferTransaction{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolTokenTransferTransaction)
 
 	if err != nil {

--- a/stacks/models/model_mempool_transaction_list_response.go
+++ b/stacks/models/model_mempool_transaction_list_response.go
@@ -183,7 +183,6 @@ func (o *MempoolTransactionListResponse) UnmarshalJSON(data []byte) (err error) 
 	varMempoolTransactionListResponse := _MempoolTransactionListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolTransactionListResponse)
 
 	if err != nil {

--- a/stacks/models/model_mempool_transaction_stats_response.go
+++ b/stacks/models/model_mempool_transaction_stats_response.go
@@ -183,7 +183,6 @@ func (o *MempoolTransactionStatsResponse) UnmarshalJSON(data []byte) (err error)
 	varMempoolTransactionStatsResponse := _MempoolTransactionStatsResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolTransactionStatsResponse)
 
 	if err != nil {

--- a/stacks/models/model_mempool_transaction_stats_response_tx_ages.go
+++ b/stacks/models/model_mempool_transaction_stats_response_tx_ages.go
@@ -183,7 +183,6 @@ func (o *MempoolTransactionStatsResponseTxAges) UnmarshalJSON(data []byte) (err 
 	varMempoolTransactionStatsResponseTxAges := _MempoolTransactionStatsResponseTxAges{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolTransactionStatsResponseTxAges)
 
 	if err != nil {

--- a/stacks/models/model_mempool_transaction_stats_response_tx_byte_sizes.go
+++ b/stacks/models/model_mempool_transaction_stats_response_tx_byte_sizes.go
@@ -183,7 +183,6 @@ func (o *MempoolTransactionStatsResponseTxByteSizes) UnmarshalJSON(data []byte) 
 	varMempoolTransactionStatsResponseTxByteSizes := _MempoolTransactionStatsResponseTxByteSizes{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolTransactionStatsResponseTxByteSizes)
 
 	if err != nil {

--- a/stacks/models/model_mempool_transaction_stats_response_tx_simple_fee_averages.go
+++ b/stacks/models/model_mempool_transaction_stats_response_tx_simple_fee_averages.go
@@ -183,7 +183,6 @@ func (o *MempoolTransactionStatsResponseTxSimpleFeeAverages) UnmarshalJSON(data 
 	varMempoolTransactionStatsResponseTxSimpleFeeAverages := _MempoolTransactionStatsResponseTxSimpleFeeAverages{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolTransactionStatsResponseTxSimpleFeeAverages)
 
 	if err != nil {

--- a/stacks/models/model_mempool_transaction_stats_response_tx_simple_fee_averages_token_transfer.go
+++ b/stacks/models/model_mempool_transaction_stats_response_tx_simple_fee_averages_token_transfer.go
@@ -191,7 +191,6 @@ func (o *MempoolTransactionStatsResponseTxSimpleFeeAveragesTokenTransfer) Unmars
 	varMempoolTransactionStatsResponseTxSimpleFeeAveragesTokenTransfer := _MempoolTransactionStatsResponseTxSimpleFeeAveragesTokenTransfer{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolTransactionStatsResponseTxSimpleFeeAveragesTokenTransfer)
 
 	if err != nil {

--- a/stacks/models/model_mempool_transaction_stats_response_tx_type_counts.go
+++ b/stacks/models/model_mempool_transaction_stats_response_tx_type_counts.go
@@ -183,7 +183,6 @@ func (o *MempoolTransactionStatsResponseTxTypeCounts) UnmarshalJSON(data []byte)
 	varMempoolTransactionStatsResponseTxTypeCounts := _MempoolTransactionStatsResponseTxTypeCounts{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolTransactionStatsResponseTxTypeCounts)
 
 	if err != nil {

--- a/stacks/models/model_mempool_tx_search_result.go
+++ b/stacks/models/model_mempool_tx_search_result.go
@@ -130,7 +130,6 @@ func (o *MempoolTxSearchResult) UnmarshalJSON(data []byte) (err error) {
 	varMempoolTxSearchResult := _MempoolTxSearchResult{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolTxSearchResult)
 
 	if err != nil {

--- a/stacks/models/model_mempool_tx_search_result_result.go
+++ b/stacks/models/model_mempool_tx_search_result_result.go
@@ -192,7 +192,6 @@ func (o *MempoolTxSearchResultResult) UnmarshalJSON(data []byte) (err error) {
 	varMempoolTxSearchResultResult := _MempoolTxSearchResultResult{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolTxSearchResultResult)
 
 	if err != nil {

--- a/stacks/models/model_mempool_tx_search_result_result_tx_data.go
+++ b/stacks/models/model_mempool_tx_search_result_result_tx_data.go
@@ -99,7 +99,6 @@ func (o *MempoolTxSearchResultResultTxData) UnmarshalJSON(data []byte) (err erro
 	varMempoolTxSearchResultResultTxData := _MempoolTxSearchResultResultTxData{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMempoolTxSearchResultResultTxData)
 
 	if err != nil {

--- a/stacks/models/model_microblock.go
+++ b/stacks/models/model_microblock.go
@@ -479,7 +479,6 @@ func (o *Microblock) UnmarshalJSON(data []byte) (err error) {
 	varMicroblock := _Microblock{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMicroblock)
 
 	if err != nil {

--- a/stacks/models/model_microblock_list_response.go
+++ b/stacks/models/model_microblock_list_response.go
@@ -188,7 +188,6 @@ func (o *MicroblockListResponse) UnmarshalJSON(data []byte) (err error) {
 	varMicroblockListResponse := _MicroblockListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varMicroblockListResponse)
 
 	if err != nil {

--- a/stacks/models/model_nakamoto_block.go
+++ b/stacks/models/model_nakamoto_block.go
@@ -622,7 +622,6 @@ func (o *NakamotoBlock) UnmarshalJSON(data []byte) (err error) {
 	varNakamotoBlock := _NakamotoBlock{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNakamotoBlock)
 
 	if err != nil {

--- a/stacks/models/model_nakamoto_block_list_response.go
+++ b/stacks/models/model_nakamoto_block_list_response.go
@@ -188,7 +188,6 @@ func (o *NakamotoBlockListResponse) UnmarshalJSON(data []byte) (err error) {
 	varNakamotoBlockListResponse := _NakamotoBlockListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNakamotoBlockListResponse)
 
 	if err != nil {

--- a/stacks/models/model_network_block_times_response.go
+++ b/stacks/models/model_network_block_times_response.go
@@ -127,7 +127,6 @@ func (o *NetworkBlockTimesResponse) UnmarshalJSON(data []byte) (err error) {
 	varNetworkBlockTimesResponse := _NetworkBlockTimesResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNetworkBlockTimesResponse)
 
 	if err != nil {

--- a/stacks/models/model_network_identifier.go
+++ b/stacks/models/model_network_identifier.go
@@ -165,7 +165,6 @@ func (o *NetworkIdentifier) UnmarshalJSON(data []byte) (err error) {
 	varNetworkIdentifier := _NetworkIdentifier{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNetworkIdentifier)
 
 	if err != nil {

--- a/stacks/models/model_network_identifier_sub_network_identifier.go
+++ b/stacks/models/model_network_identifier_sub_network_identifier.go
@@ -136,7 +136,6 @@ func (o *NetworkIdentifierSubNetworkIdentifier) UnmarshalJSON(data []byte) (err 
 	varNetworkIdentifierSubNetworkIdentifier := _NetworkIdentifierSubNetworkIdentifier{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNetworkIdentifierSubNetworkIdentifier)
 
 	if err != nil {

--- a/stacks/models/model_network_identifier_sub_network_identifier_metadata.go
+++ b/stacks/models/model_network_identifier_sub_network_identifier_metadata.go
@@ -100,7 +100,6 @@ func (o *NetworkIdentifierSubNetworkIdentifierMetadata) UnmarshalJSON(data []byt
 	varNetworkIdentifierSubNetworkIdentifierMetadata := _NetworkIdentifierSubNetworkIdentifierMetadata{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNetworkIdentifierSubNetworkIdentifierMetadata)
 
 	if err != nil {

--- a/stacks/models/model_nft_balance.go
+++ b/stacks/models/model_nft_balance.go
@@ -155,7 +155,6 @@ func (o *NftBalance) UnmarshalJSON(data []byte) (err error) {
 	varNftBalance := _NftBalance{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNftBalance)
 
 	if err != nil {

--- a/stacks/models/model_non_fungible_token_history_event_list.go
+++ b/stacks/models/model_non_fungible_token_history_event_list.go
@@ -186,7 +186,6 @@ func (o *NonFungibleTokenHistoryEventList) UnmarshalJSON(data []byte) (err error
 	varNonFungibleTokenHistoryEventList := _NonFungibleTokenHistoryEventList{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNonFungibleTokenHistoryEventList)
 
 	if err != nil {

--- a/stacks/models/model_non_fungible_token_history_event_with_tx_id.go
+++ b/stacks/models/model_non_fungible_token_history_event_with_tx_id.go
@@ -238,7 +238,6 @@ func (o *NonFungibleTokenHistoryEventWithTxId) UnmarshalJSON(data []byte) (err e
 	varNonFungibleTokenHistoryEventWithTxId := _NonFungibleTokenHistoryEventWithTxId{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNonFungibleTokenHistoryEventWithTxId)
 
 	if err != nil {

--- a/stacks/models/model_non_fungible_token_history_event_with_tx_metadata.go
+++ b/stacks/models/model_non_fungible_token_history_event_with_tx_metadata.go
@@ -238,7 +238,6 @@ func (o *NonFungibleTokenHistoryEventWithTxMetadata) UnmarshalJSON(data []byte) 
 	varNonFungibleTokenHistoryEventWithTxMetadata := _NonFungibleTokenHistoryEventWithTxMetadata{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNonFungibleTokenHistoryEventWithTxMetadata)
 
 	if err != nil {

--- a/stacks/models/model_non_fungible_token_holding_with_tx_id.go
+++ b/stacks/models/model_non_fungible_token_holding_with_tx_id.go
@@ -183,7 +183,6 @@ func (o *NonFungibleTokenHoldingWithTxId) UnmarshalJSON(data []byte) (err error)
 	varNonFungibleTokenHoldingWithTxId := _NonFungibleTokenHoldingWithTxId{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNonFungibleTokenHoldingWithTxId)
 
 	if err != nil {

--- a/stacks/models/model_non_fungible_token_holding_with_tx_id_value.go
+++ b/stacks/models/model_non_fungible_token_holding_with_tx_id_value.go
@@ -129,7 +129,6 @@ func (o *NonFungibleTokenHoldingWithTxIdValue) UnmarshalJSON(data []byte) (err e
 	varNonFungibleTokenHoldingWithTxIdValue := _NonFungibleTokenHoldingWithTxIdValue{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNonFungibleTokenHoldingWithTxIdValue)
 
 	if err != nil {

--- a/stacks/models/model_non_fungible_token_holding_with_tx_metadata.go
+++ b/stacks/models/model_non_fungible_token_holding_with_tx_metadata.go
@@ -183,7 +183,6 @@ func (o *NonFungibleTokenHoldingWithTxMetadata) UnmarshalJSON(data []byte) (err 
 	varNonFungibleTokenHoldingWithTxMetadata := _NonFungibleTokenHoldingWithTxMetadata{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNonFungibleTokenHoldingWithTxMetadata)
 
 	if err != nil {

--- a/stacks/models/model_non_fungible_token_holdings_list.go
+++ b/stacks/models/model_non_fungible_token_holdings_list.go
@@ -186,7 +186,6 @@ func (o *NonFungibleTokenHoldingsList) UnmarshalJSON(data []byte) (err error) {
 	varNonFungibleTokenHoldingsList := _NonFungibleTokenHoldingsList{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNonFungibleTokenHoldingsList)
 
 	if err != nil {

--- a/stacks/models/model_non_fungible_token_mint_list.go
+++ b/stacks/models/model_non_fungible_token_mint_list.go
@@ -186,7 +186,6 @@ func (o *NonFungibleTokenMintList) UnmarshalJSON(data []byte) (err error) {
 	varNonFungibleTokenMintList := _NonFungibleTokenMintList{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNonFungibleTokenMintList)
 
 	if err != nil {

--- a/stacks/models/model_non_fungible_token_mint_with_tx_id.go
+++ b/stacks/models/model_non_fungible_token_mint_with_tx_id.go
@@ -191,7 +191,6 @@ func (o *NonFungibleTokenMintWithTxId) UnmarshalJSON(data []byte) (err error) {
 	varNonFungibleTokenMintWithTxId := _NonFungibleTokenMintWithTxId{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNonFungibleTokenMintWithTxId)
 
 	if err != nil {

--- a/stacks/models/model_non_fungible_token_mint_with_tx_metadata.go
+++ b/stacks/models/model_non_fungible_token_mint_with_tx_metadata.go
@@ -191,7 +191,6 @@ func (o *NonFungibleTokenMintWithTxMetadata) UnmarshalJSON(data []byte) (err err
 	varNonFungibleTokenMintWithTxMetadata := _NonFungibleTokenMintWithTxMetadata{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varNonFungibleTokenMintWithTxMetadata)
 
 	if err != nil {

--- a/stacks/models/model_other_transaction_identifier.go
+++ b/stacks/models/model_other_transaction_identifier.go
@@ -100,7 +100,6 @@ func (o *OtherTransactionIdentifier) UnmarshalJSON(data []byte) (err error) {
 	varOtherTransactionIdentifier := _OtherTransactionIdentifier{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varOtherTransactionIdentifier)
 
 	if err != nil {

--- a/stacks/models/model_poison_microblock_transaction.go
+++ b/stacks/models/model_poison_microblock_transaction.go
@@ -1155,7 +1155,6 @@ func (o *PoisonMicroblockTransaction) UnmarshalJSON(data []byte) (err error) {
 	varPoisonMicroblockTransaction := _PoisonMicroblockTransaction{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPoisonMicroblockTransaction)
 
 	if err != nil {

--- a/stacks/models/model_poison_microblock_transaction_metadata_poison_microblock.go
+++ b/stacks/models/model_poison_microblock_transaction_metadata_poison_microblock.go
@@ -129,7 +129,6 @@ func (o *PoisonMicroblockTransactionMetadataPoisonMicroblock) UnmarshalJSON(data
 	varPoisonMicroblockTransactionMetadataPoisonMicroblock := _PoisonMicroblockTransactionMetadataPoisonMicroblock{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPoisonMicroblockTransactionMetadataPoisonMicroblock)
 
 	if err != nil {

--- a/stacks/models/model_pool_delegation.go
+++ b/stacks/models/model_pool_delegation.go
@@ -261,7 +261,6 @@ func (o *PoolDelegation) UnmarshalJSON(data []byte) (err error) {
 	varPoolDelegation := _PoolDelegation{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPoolDelegation)
 
 	if err != nil {

--- a/stacks/models/model_pool_delegations_response.go
+++ b/stacks/models/model_pool_delegations_response.go
@@ -188,7 +188,6 @@ func (o *PoolDelegationsResponse) UnmarshalJSON(data []byte) (err error) {
 	varPoolDelegationsResponse := _PoolDelegationsResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPoolDelegationsResponse)
 
 	if err != nil {

--- a/stacks/models/model_post_condition_fungible.go
+++ b/stacks/models/model_post_condition_fungible.go
@@ -212,7 +212,6 @@ func (o *PostConditionFungible) UnmarshalJSON(data []byte) (err error) {
 	varPostConditionFungible := _PostConditionFungible{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPostConditionFungible)
 
 	if err != nil {

--- a/stacks/models/model_post_condition_fungible_all_of_asset.go
+++ b/stacks/models/model_post_condition_fungible_all_of_asset.go
@@ -155,7 +155,6 @@ func (o *PostConditionFungibleAllOfAsset) UnmarshalJSON(data []byte) (err error)
 	varPostConditionFungibleAllOfAsset := _PostConditionFungibleAllOfAsset{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPostConditionFungibleAllOfAsset)
 
 	if err != nil {

--- a/stacks/models/model_post_condition_non_fungible.go
+++ b/stacks/models/model_post_condition_non_fungible.go
@@ -212,7 +212,6 @@ func (o *PostConditionNonFungible) UnmarshalJSON(data []byte) (err error) {
 	varPostConditionNonFungible := _PostConditionNonFungible{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPostConditionNonFungible)
 
 	if err != nil {

--- a/stacks/models/model_post_condition_non_fungible_all_of_asset_value.go
+++ b/stacks/models/model_post_condition_non_fungible_all_of_asset_value.go
@@ -127,7 +127,6 @@ func (o *PostConditionNonFungibleAllOfAssetValue) UnmarshalJSON(data []byte) (er
 	varPostConditionNonFungibleAllOfAssetValue := _PostConditionNonFungibleAllOfAssetValue{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPostConditionNonFungibleAllOfAssetValue)
 
 	if err != nil {

--- a/stacks/models/model_post_condition_principal_any_of.go
+++ b/stacks/models/model_post_condition_principal_any_of.go
@@ -100,7 +100,6 @@ func (o *PostConditionPrincipalAnyOf) UnmarshalJSON(data []byte) (err error) {
 	varPostConditionPrincipalAnyOf := _PostConditionPrincipalAnyOf{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPostConditionPrincipalAnyOf)
 
 	if err != nil {

--- a/stacks/models/model_post_condition_principal_any_of_1.go
+++ b/stacks/models/model_post_condition_principal_any_of_1.go
@@ -128,7 +128,6 @@ func (o *PostConditionPrincipalAnyOf1) UnmarshalJSON(data []byte) (err error) {
 	varPostConditionPrincipalAnyOf1 := _PostConditionPrincipalAnyOf1{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPostConditionPrincipalAnyOf1)
 
 	if err != nil {

--- a/stacks/models/model_post_condition_principal_any_of_2.go
+++ b/stacks/models/model_post_condition_principal_any_of_2.go
@@ -156,7 +156,6 @@ func (o *PostConditionPrincipalAnyOf2) UnmarshalJSON(data []byte) (err error) {
 	varPostConditionPrincipalAnyOf2 := _PostConditionPrincipalAnyOf2{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPostConditionPrincipalAnyOf2)
 
 	if err != nil {

--- a/stacks/models/model_post_condition_stx.go
+++ b/stacks/models/model_post_condition_stx.go
@@ -184,7 +184,6 @@ func (o *PostConditionStx) UnmarshalJSON(data []byte) (err error) {
 	varPostConditionStx := _PostConditionStx{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPostConditionStx)
 
 	if err != nil {

--- a/stacks/models/model_post_core_node_transactions_error.go
+++ b/stacks/models/model_post_core_node_transactions_error.go
@@ -187,7 +187,6 @@ func (o *PostCoreNodeTransactionsError) UnmarshalJSON(data []byte) (err error) {
 	varPostCoreNodeTransactionsError := _PostCoreNodeTransactionsError{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPostCoreNodeTransactionsError)
 
 	if err != nil {

--- a/stacks/models/model_pox_cycle.go
+++ b/stacks/models/model_pox_cycle.go
@@ -239,7 +239,6 @@ func (o *PoxCycle) UnmarshalJSON(data []byte) (err error) {
 	varPoxCycle := _PoxCycle{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPoxCycle)
 
 	if err != nil {

--- a/stacks/models/model_pox_cycle_list_response.go
+++ b/stacks/models/model_pox_cycle_list_response.go
@@ -188,7 +188,6 @@ func (o *PoxCycleListResponse) UnmarshalJSON(data []byte) (err error) {
 	varPoxCycleListResponse := _PoxCycleListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPoxCycleListResponse)
 
 	if err != nil {

--- a/stacks/models/model_pox_cycle_signer_stackers_list_response.go
+++ b/stacks/models/model_pox_cycle_signer_stackers_list_response.go
@@ -188,7 +188,6 @@ func (o *PoxCycleSignerStackersListResponse) UnmarshalJSON(data []byte) (err err
 	varPoxCycleSignerStackersListResponse := _PoxCycleSignerStackersListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPoxCycleSignerStackersListResponse)
 
 	if err != nil {

--- a/stacks/models/model_pox_cycle_signers_list_response.go
+++ b/stacks/models/model_pox_cycle_signers_list_response.go
@@ -188,7 +188,6 @@ func (o *PoxCycleSignersListResponse) UnmarshalJSON(data []byte) (err error) {
 	varPoxCycleSignersListResponse := _PoxCycleSignersListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPoxCycleSignersListResponse)
 
 	if err != nil {

--- a/stacks/models/model_pox_signer.go
+++ b/stacks/models/model_pox_signer.go
@@ -298,7 +298,6 @@ func (o *PoxSigner) UnmarshalJSON(data []byte) (err error) {
 	varPoxSigner := _PoxSigner{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPoxSigner)
 
 	if err != nil {

--- a/stacks/models/model_pox_stacker.go
+++ b/stacks/models/model_pox_stacker.go
@@ -183,7 +183,6 @@ func (o *PoxStacker) UnmarshalJSON(data []byte) (err error) {
 	varPoxStacker := _PoxStacker{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varPoxStacker)
 
 	if err != nil {

--- a/stacks/models/model_read_only_function_args.go
+++ b/stacks/models/model_read_only_function_args.go
@@ -129,7 +129,6 @@ func (o *ReadOnlyFunctionArgs) UnmarshalJSON(data []byte) (err error) {
 	varReadOnlyFunctionArgs := _ReadOnlyFunctionArgs{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varReadOnlyFunctionArgs)
 
 	if err != nil {

--- a/stacks/models/model_read_only_function_success_response.go
+++ b/stacks/models/model_read_only_function_success_response.go
@@ -171,7 +171,6 @@ func (o *ReadOnlyFunctionSuccessResponse) UnmarshalJSON(data []byte) (err error)
 	varReadOnlyFunctionSuccessResponse := _ReadOnlyFunctionSuccessResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varReadOnlyFunctionSuccessResponse)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_account.go
+++ b/stacks/models/model_rosetta_account.go
@@ -173,7 +173,6 @@ func (o *RosettaAccount) UnmarshalJSON(data []byte) (err error) {
 	varRosettaAccount := _RosettaAccount{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaAccount)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_account_balance_request.go
+++ b/stacks/models/model_rosetta_account_balance_request.go
@@ -163,7 +163,6 @@ func (o *RosettaAccountBalanceRequest) UnmarshalJSON(data []byte) (err error) {
 	varRosettaAccountBalanceRequest := _RosettaAccountBalanceRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaAccountBalanceRequest)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_account_balance_response.go
+++ b/stacks/models/model_rosetta_account_balance_response.go
@@ -201,7 +201,6 @@ func (o *RosettaAccountBalanceResponse) UnmarshalJSON(data []byte) (err error) {
 	varRosettaAccountBalanceResponse := _RosettaAccountBalanceResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaAccountBalanceResponse)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_account_balance_response_metadata.go
+++ b/stacks/models/model_rosetta_account_balance_response_metadata.go
@@ -99,7 +99,6 @@ func (o *RosettaAccountBalanceResponseMetadata) UnmarshalJSON(data []byte) (err 
 	varRosettaAccountBalanceResponseMetadata := _RosettaAccountBalanceResponseMetadata{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaAccountBalanceResponseMetadata)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_account_identifier.go
+++ b/stacks/models/model_rosetta_account_identifier.go
@@ -173,7 +173,6 @@ func (o *RosettaAccountIdentifier) UnmarshalJSON(data []byte) (err error) {
 	varRosettaAccountIdentifier := _RosettaAccountIdentifier{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaAccountIdentifier)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_amount.go
+++ b/stacks/models/model_rosetta_amount.go
@@ -165,7 +165,6 @@ func (o *RosettaAmount) UnmarshalJSON(data []byte) (err error) {
 	varRosettaAmount := _RosettaAmount{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaAmount)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_block.go
+++ b/stacks/models/model_rosetta_block.go
@@ -213,7 +213,6 @@ func (o *RosettaBlock) UnmarshalJSON(data []byte) (err error) {
 	varRosettaBlock := _RosettaBlock{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaBlock)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_block_identifier.go
+++ b/stacks/models/model_rosetta_block_identifier.go
@@ -129,7 +129,6 @@ func (o *RosettaBlockIdentifier) UnmarshalJSON(data []byte) (err error) {
 	varRosettaBlockIdentifier := _RosettaBlockIdentifier{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaBlockIdentifier)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_block_identifier_hash.go
+++ b/stacks/models/model_rosetta_block_identifier_hash.go
@@ -100,7 +100,6 @@ func (o *RosettaBlockIdentifierHash) UnmarshalJSON(data []byte) (err error) {
 	varRosettaBlockIdentifierHash := _RosettaBlockIdentifierHash{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaBlockIdentifierHash)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_block_identifier_height.go
+++ b/stacks/models/model_rosetta_block_identifier_height.go
@@ -100,7 +100,6 @@ func (o *RosettaBlockIdentifierHeight) UnmarshalJSON(data []byte) (err error) {
 	varRosettaBlockIdentifierHeight := _RosettaBlockIdentifierHeight{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaBlockIdentifierHeight)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_block_metadata.go
+++ b/stacks/models/model_rosetta_block_metadata.go
@@ -100,7 +100,6 @@ func (o *RosettaBlockMetadata) UnmarshalJSON(data []byte) (err error) {
 	varRosettaBlockMetadata := _RosettaBlockMetadata{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaBlockMetadata)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_block_request.go
+++ b/stacks/models/model_rosetta_block_request.go
@@ -127,7 +127,6 @@ func (o *RosettaBlockRequest) UnmarshalJSON(data []byte) (err error) {
 	varRosettaBlockRequest := _RosettaBlockRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaBlockRequest)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_block_transaction_request.go
+++ b/stacks/models/model_rosetta_block_transaction_request.go
@@ -155,7 +155,6 @@ func (o *RosettaBlockTransactionRequest) UnmarshalJSON(data []byte) (err error) 
 	varRosettaBlockTransactionRequest := _RosettaBlockTransactionRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaBlockTransactionRequest)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_block_transaction_response.go
+++ b/stacks/models/model_rosetta_block_transaction_response.go
@@ -99,7 +99,6 @@ func (o *RosettaBlockTransactionResponse) UnmarshalJSON(data []byte) (err error)
 	varRosettaBlockTransactionResponse := _RosettaBlockTransactionResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaBlockTransactionResponse)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_coin.go
+++ b/stacks/models/model_rosetta_coin.go
@@ -127,7 +127,6 @@ func (o *RosettaCoin) UnmarshalJSON(data []byte) (err error) {
 	varRosettaCoin := _RosettaCoin{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaCoin)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_coin_change.go
+++ b/stacks/models/model_rosetta_coin_change.go
@@ -128,7 +128,6 @@ func (o *RosettaCoinChange) UnmarshalJSON(data []byte) (err error) {
 	varRosettaCoinChange := _RosettaCoinChange{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaCoinChange)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_coin_change_coin_identifier.go
+++ b/stacks/models/model_rosetta_coin_change_coin_identifier.go
@@ -100,7 +100,6 @@ func (o *RosettaCoinChangeCoinIdentifier) UnmarshalJSON(data []byte) (err error)
 	varRosettaCoinChangeCoinIdentifier := _RosettaCoinChangeCoinIdentifier{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaCoinChangeCoinIdentifier)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_coin_coin_identifier.go
+++ b/stacks/models/model_rosetta_coin_coin_identifier.go
@@ -100,7 +100,6 @@ func (o *RosettaCoinCoinIdentifier) UnmarshalJSON(data []byte) (err error) {
 	varRosettaCoinCoinIdentifier := _RosettaCoinCoinIdentifier{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaCoinCoinIdentifier)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_construction_combine_request.go
+++ b/stacks/models/model_rosetta_construction_combine_request.go
@@ -155,7 +155,6 @@ func (o *RosettaConstructionCombineRequest) UnmarshalJSON(data []byte) (err erro
 	varRosettaConstructionCombineRequest := _RosettaConstructionCombineRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaConstructionCombineRequest)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_construction_combine_response.go
+++ b/stacks/models/model_rosetta_construction_combine_response.go
@@ -100,7 +100,6 @@ func (o *RosettaConstructionCombineResponse) UnmarshalJSON(data []byte) (err err
 	varRosettaConstructionCombineResponse := _RosettaConstructionCombineResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaConstructionCombineResponse)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_construction_derive_request.go
+++ b/stacks/models/model_rosetta_construction_derive_request.go
@@ -163,7 +163,6 @@ func (o *RosettaConstructionDeriveRequest) UnmarshalJSON(data []byte) (err error
 	varRosettaConstructionDeriveRequest := _RosettaConstructionDeriveRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaConstructionDeriveRequest)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_construction_hash_request.go
+++ b/stacks/models/model_rosetta_construction_hash_request.go
@@ -128,7 +128,6 @@ func (o *RosettaConstructionHashRequest) UnmarshalJSON(data []byte) (err error) 
 	varRosettaConstructionHashRequest := _RosettaConstructionHashRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaConstructionHashRequest)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_construction_hash_response.go
+++ b/stacks/models/model_rosetta_construction_hash_response.go
@@ -135,7 +135,6 @@ func (o *RosettaConstructionHashResponse) UnmarshalJSON(data []byte) (err error)
 	varRosettaConstructionHashResponse := _RosettaConstructionHashResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaConstructionHashResponse)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_construction_metadata_request.go
+++ b/stacks/models/model_rosetta_construction_metadata_request.go
@@ -163,7 +163,6 @@ func (o *RosettaConstructionMetadataRequest) UnmarshalJSON(data []byte) (err err
 	varRosettaConstructionMetadataRequest := _RosettaConstructionMetadataRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaConstructionMetadataRequest)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_construction_metadata_response.go
+++ b/stacks/models/model_rosetta_construction_metadata_response.go
@@ -135,7 +135,6 @@ func (o *RosettaConstructionMetadataResponse) UnmarshalJSON(data []byte) (err er
 	varRosettaConstructionMetadataResponse := _RosettaConstructionMetadataResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaConstructionMetadataResponse)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_construction_parse_request.go
+++ b/stacks/models/model_rosetta_construction_parse_request.go
@@ -157,7 +157,6 @@ func (o *RosettaConstructionParseRequest) UnmarshalJSON(data []byte) (err error)
 	varRosettaConstructionParseRequest := _RosettaConstructionParseRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaConstructionParseRequest)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_construction_parse_response.go
+++ b/stacks/models/model_rosetta_construction_parse_response.go
@@ -208,7 +208,6 @@ func (o *RosettaConstructionParseResponse) UnmarshalJSON(data []byte) (err error
 	varRosettaConstructionParseResponse := _RosettaConstructionParseResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaConstructionParseResponse)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_construction_payload_response.go
+++ b/stacks/models/model_rosetta_construction_payload_response.go
@@ -129,7 +129,6 @@ func (o *RosettaConstructionPayloadResponse) UnmarshalJSON(data []byte) (err err
 	varRosettaConstructionPayloadResponse := _RosettaConstructionPayloadResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaConstructionPayloadResponse)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_construction_payloads_request.go
+++ b/stacks/models/model_rosetta_construction_payloads_request.go
@@ -199,7 +199,6 @@ func (o *RosettaConstructionPayloadsRequest) UnmarshalJSON(data []byte) (err err
 	varRosettaConstructionPayloadsRequest := _RosettaConstructionPayloadsRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaConstructionPayloadsRequest)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_construction_preprocess_request.go
+++ b/stacks/models/model_rosetta_construction_preprocess_request.go
@@ -236,7 +236,6 @@ func (o *RosettaConstructionPreprocessRequest) UnmarshalJSON(data []byte) (err e
 	varRosettaConstructionPreprocessRequest := _RosettaConstructionPreprocessRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaConstructionPreprocessRequest)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_construction_submit_request.go
+++ b/stacks/models/model_rosetta_construction_submit_request.go
@@ -128,7 +128,6 @@ func (o *RosettaConstructionSubmitRequest) UnmarshalJSON(data []byte) (err error
 	varRosettaConstructionSubmitRequest := _RosettaConstructionSubmitRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaConstructionSubmitRequest)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_construction_submit_response.go
+++ b/stacks/models/model_rosetta_construction_submit_response.go
@@ -135,7 +135,6 @@ func (o *RosettaConstructionSubmitResponse) UnmarshalJSON(data []byte) (err erro
 	varRosettaConstructionSubmitResponse := _RosettaConstructionSubmitResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaConstructionSubmitResponse)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_currency.go
+++ b/stacks/models/model_rosetta_currency.go
@@ -166,7 +166,6 @@ func (o *RosettaCurrency) UnmarshalJSON(data []byte) (err error) {
 	varRosettaCurrency := _RosettaCurrency{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaCurrency)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_error.go
+++ b/stacks/models/model_rosetta_error.go
@@ -194,7 +194,6 @@ func (o *RosettaError) UnmarshalJSON(data []byte) (err error) {
 	varRosettaError := _RosettaError{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaError)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_error_no_details.go
+++ b/stacks/models/model_rosetta_error_no_details.go
@@ -158,7 +158,6 @@ func (o *RosettaErrorNoDetails) UnmarshalJSON(data []byte) (err error) {
 	varRosettaErrorNoDetails := _RosettaErrorNoDetails{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaErrorNoDetails)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_genesis_block_identifier.go
+++ b/stacks/models/model_rosetta_genesis_block_identifier.go
@@ -129,7 +129,6 @@ func (o *RosettaGenesisBlockIdentifier) UnmarshalJSON(data []byte) (err error) {
 	varRosettaGenesisBlockIdentifier := _RosettaGenesisBlockIdentifier{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaGenesisBlockIdentifier)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_max_fee_amount.go
+++ b/stacks/models/model_rosetta_max_fee_amount.go
@@ -165,7 +165,6 @@ func (o *RosettaMaxFeeAmount) UnmarshalJSON(data []byte) (err error) {
 	varRosettaMaxFeeAmount := _RosettaMaxFeeAmount{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaMaxFeeAmount)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_mempool_request.go
+++ b/stacks/models/model_rosetta_mempool_request.go
@@ -135,7 +135,6 @@ func (o *RosettaMempoolRequest) UnmarshalJSON(data []byte) (err error) {
 	varRosettaMempoolRequest := _RosettaMempoolRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaMempoolRequest)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_mempool_response.go
+++ b/stacks/models/model_rosetta_mempool_response.go
@@ -136,7 +136,6 @@ func (o *RosettaMempoolResponse) UnmarshalJSON(data []byte) (err error) {
 	varRosettaMempoolResponse := _RosettaMempoolResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaMempoolResponse)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_mempool_transaction_request.go
+++ b/stacks/models/model_rosetta_mempool_transaction_request.go
@@ -127,7 +127,6 @@ func (o *RosettaMempoolTransactionRequest) UnmarshalJSON(data []byte) (err error
 	varRosettaMempoolTransactionRequest := _RosettaMempoolTransactionRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaMempoolTransactionRequest)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_mempool_transaction_response.go
+++ b/stacks/models/model_rosetta_mempool_transaction_response.go
@@ -135,7 +135,6 @@ func (o *RosettaMempoolTransactionResponse) UnmarshalJSON(data []byte) (err erro
 	varRosettaMempoolTransactionResponse := _RosettaMempoolTransactionResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaMempoolTransactionResponse)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_network_list_response.go
+++ b/stacks/models/model_rosetta_network_list_response.go
@@ -100,7 +100,6 @@ func (o *RosettaNetworkListResponse) UnmarshalJSON(data []byte) (err error) {
 	varRosettaNetworkListResponse := _RosettaNetworkListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaNetworkListResponse)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_network_options_response.go
+++ b/stacks/models/model_rosetta_network_options_response.go
@@ -127,7 +127,6 @@ func (o *RosettaNetworkOptionsResponse) UnmarshalJSON(data []byte) (err error) {
 	varRosettaNetworkOptionsResponse := _RosettaNetworkOptionsResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaNetworkOptionsResponse)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_network_options_response_allow.go
+++ b/stacks/models/model_rosetta_network_options_response_allow.go
@@ -187,7 +187,6 @@ func (o *RosettaNetworkOptionsResponseAllow) UnmarshalJSON(data []byte) (err err
 	varRosettaNetworkOptionsResponseAllow := _RosettaNetworkOptionsResponseAllow{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaNetworkOptionsResponseAllow)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_network_options_response_version.go
+++ b/stacks/models/model_rosetta_network_options_response_version.go
@@ -203,7 +203,6 @@ func (o *RosettaNetworkOptionsResponseVersion) UnmarshalJSON(data []byte) (err e
 	varRosettaNetworkOptionsResponseVersion := _RosettaNetworkOptionsResponseVersion{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaNetworkOptionsResponseVersion)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_network_status_response.go
+++ b/stacks/models/model_rosetta_network_status_response.go
@@ -286,7 +286,6 @@ func (o *RosettaNetworkStatusResponse) UnmarshalJSON(data []byte) (err error) {
 	varRosettaNetworkStatusResponse := _RosettaNetworkStatusResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaNetworkStatusResponse)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_oldest_block_identifier.go
+++ b/stacks/models/model_rosetta_oldest_block_identifier.go
@@ -129,7 +129,6 @@ func (o *RosettaOldestBlockIdentifier) UnmarshalJSON(data []byte) (err error) {
 	varRosettaOldestBlockIdentifier := _RosettaOldestBlockIdentifier{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaOldestBlockIdentifier)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_operation.go
+++ b/stacks/models/model_rosetta_operation.go
@@ -347,7 +347,6 @@ func (o *RosettaOperation) UnmarshalJSON(data []byte) (err error) {
 	varRosettaOperation := _RosettaOperation{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaOperation)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_operation_identifier.go
+++ b/stacks/models/model_rosetta_operation_identifier.go
@@ -137,7 +137,6 @@ func (o *RosettaOperationIdentifier) UnmarshalJSON(data []byte) (err error) {
 	varRosettaOperationIdentifier := _RosettaOperationIdentifier{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaOperationIdentifier)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_operation_status.go
+++ b/stacks/models/model_rosetta_operation_status.go
@@ -129,7 +129,6 @@ func (o *RosettaOperationStatus) UnmarshalJSON(data []byte) (err error) {
 	varRosettaOperationStatus := _RosettaOperationStatus{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaOperationStatus)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_options_request.go
+++ b/stacks/models/model_rosetta_options_request.go
@@ -135,7 +135,6 @@ func (o *RosettaOptionsRequest) UnmarshalJSON(data []byte) (err error) {
 	varRosettaOptionsRequest := _RosettaOptionsRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaOptionsRequest)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_parent_block_identifier.go
+++ b/stacks/models/model_rosetta_parent_block_identifier.go
@@ -129,7 +129,6 @@ func (o *RosettaParentBlockIdentifier) UnmarshalJSON(data []byte) (err error) {
 	varRosettaParentBlockIdentifier := _RosettaParentBlockIdentifier{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaParentBlockIdentifier)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_peers.go
+++ b/stacks/models/model_rosetta_peers.go
@@ -137,7 +137,6 @@ func (o *RosettaPeers) UnmarshalJSON(data []byte) (err error) {
 	varRosettaPeers := _RosettaPeers{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaPeers)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_public_key.go
+++ b/stacks/models/model_rosetta_public_key.go
@@ -129,7 +129,6 @@ func (o *RosettaPublicKey) UnmarshalJSON(data []byte) (err error) {
 	varRosettaPublicKey := _RosettaPublicKey{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaPublicKey)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_related_operation.go
+++ b/stacks/models/model_rosetta_related_operation.go
@@ -137,7 +137,6 @@ func (o *RosettaRelatedOperation) UnmarshalJSON(data []byte) (err error) {
 	varRosettaRelatedOperation := _RosettaRelatedOperation{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaRelatedOperation)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_signature.go
+++ b/stacks/models/model_rosetta_signature.go
@@ -184,7 +184,6 @@ func (o *RosettaSignature) UnmarshalJSON(data []byte) (err error) {
 	varRosettaSignature := _RosettaSignature{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaSignature)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_status_request.go
+++ b/stacks/models/model_rosetta_status_request.go
@@ -135,7 +135,6 @@ func (o *RosettaStatusRequest) UnmarshalJSON(data []byte) (err error) {
 	varRosettaStatusRequest := _RosettaStatusRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaStatusRequest)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_sub_account.go
+++ b/stacks/models/model_rosetta_sub_account.go
@@ -137,7 +137,6 @@ func (o *RosettaSubAccount) UnmarshalJSON(data []byte) (err error) {
 	varRosettaSubAccount := _RosettaSubAccount{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaSubAccount)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_sync_status.go
+++ b/stacks/models/model_rosetta_sync_status.go
@@ -211,7 +211,6 @@ func (o *RosettaSyncStatus) UnmarshalJSON(data []byte) (err error) {
 	varRosettaSyncStatus := _RosettaSyncStatus{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaSyncStatus)
 
 	if err != nil {

--- a/stacks/models/model_rosetta_transaction.go
+++ b/stacks/models/model_rosetta_transaction.go
@@ -164,7 +164,6 @@ func (o *RosettaTransaction) UnmarshalJSON(data []byte) (err error) {
 	varRosettaTransaction := _RosettaTransaction{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRosettaTransaction)
 
 	if err != nil {

--- a/stacks/models/model_run_faucet_response.go
+++ b/stacks/models/model_run_faucet_response.go
@@ -174,7 +174,6 @@ func (o *RunFaucetResponse) UnmarshalJSON(data []byte) (err error) {
 	varRunFaucetResponse := _RunFaucetResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varRunFaucetResponse)
 
 	if err != nil {

--- a/stacks/models/model_search_error_result.go
+++ b/stacks/models/model_search_error_result.go
@@ -158,7 +158,6 @@ func (o *SearchErrorResult) UnmarshalJSON(data []byte) (err error) {
 	varSearchErrorResult := _SearchErrorResult{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSearchErrorResult)
 
 	if err != nil {

--- a/stacks/models/model_search_error_result_result.go
+++ b/stacks/models/model_search_error_result_result.go
@@ -100,7 +100,6 @@ func (o *SearchErrorResultResult) UnmarshalJSON(data []byte) (err error) {
 	varSearchErrorResultResult := _SearchErrorResultResult{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSearchErrorResultResult)
 
 	if err != nil {

--- a/stacks/models/model_server_status_response.go
+++ b/stacks/models/model_server_status_response.go
@@ -314,7 +314,6 @@ func (o *ServerStatusResponse) UnmarshalJSON(data []byte) (err error) {
 	varServerStatusResponse := _ServerStatusResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varServerStatusResponse)
 
 	if err != nil {

--- a/stacks/models/model_signing_payload.go
+++ b/stacks/models/model_signing_payload.go
@@ -209,7 +209,6 @@ func (o *SigningPayload) UnmarshalJSON(data []byte) (err error) {
 	varSigningPayload := _SigningPayload{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSigningPayload)
 
 	if err != nil {

--- a/stacks/models/model_smart_contract.go
+++ b/stacks/models/model_smart_contract.go
@@ -239,7 +239,6 @@ func (o *SmartContract) UnmarshalJSON(data []byte) (err error) {
 	varSmartContract := _SmartContract{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSmartContract)
 
 	if err != nil {

--- a/stacks/models/model_smart_contract_found.go
+++ b/stacks/models/model_smart_contract_found.go
@@ -127,7 +127,6 @@ func (o *SmartContractFound) UnmarshalJSON(data []byte) (err error) {
 	varSmartContractFound := _SmartContractFound{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSmartContractFound)
 
 	if err != nil {

--- a/stacks/models/model_smart_contract_not_found.go
+++ b/stacks/models/model_smart_contract_not_found.go
@@ -99,7 +99,6 @@ func (o *SmartContractNotFound) UnmarshalJSON(data []byte) (err error) {
 	varSmartContractNotFound := _SmartContractNotFound{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSmartContractNotFound)
 
 	if err != nil {

--- a/stacks/models/model_smart_contract_status.go
+++ b/stacks/models/model_smart_contract_status.go
@@ -195,7 +195,6 @@ func (o *SmartContractStatus) UnmarshalJSON(data []byte) (err error) {
 	varSmartContractStatus := _SmartContractStatus{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSmartContractStatus)
 
 	if err != nil {

--- a/stacks/models/model_smart_contract_transaction.go
+++ b/stacks/models/model_smart_contract_transaction.go
@@ -1155,7 +1155,6 @@ func (o *SmartContractTransaction) UnmarshalJSON(data []byte) (err error) {
 	varSmartContractTransaction := _SmartContractTransaction{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSmartContractTransaction)
 
 	if err != nil {

--- a/stacks/models/model_smart_contract_transaction_metadata_smart_contract.go
+++ b/stacks/models/model_smart_contract_transaction_metadata_smart_contract.go
@@ -177,7 +177,6 @@ func (o *SmartContractTransactionMetadataSmartContract) UnmarshalJSON(data []byt
 	varSmartContractTransactionMetadataSmartContract := _SmartContractTransactionMetadataSmartContract{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varSmartContractTransactionMetadataSmartContract)
 
 	if err != nil {

--- a/stacks/models/model_stx_balance.go
+++ b/stacks/models/model_stx_balance.go
@@ -356,7 +356,6 @@ func (o *StxBalance) UnmarshalJSON(data []byte) (err error) {
 	varStxBalance := _StxBalance{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varStxBalance)
 
 	if err != nil {

--- a/stacks/models/model_target_block_time.go
+++ b/stacks/models/model_target_block_time.go
@@ -99,7 +99,6 @@ func (o *TargetBlockTime) UnmarshalJSON(data []byte) (err error) {
 	varTargetBlockTime := _TargetBlockTime{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTargetBlockTime)
 
 	if err != nil {

--- a/stacks/models/model_tenure_change_transaction.go
+++ b/stacks/models/model_tenure_change_transaction.go
@@ -1163,7 +1163,6 @@ func (o *TenureChangeTransaction) UnmarshalJSON(data []byte) (err error) {
 	varTenureChangeTransaction := _TenureChangeTransaction{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTenureChangeTransaction)
 
 	if err != nil {

--- a/stacks/models/model_tenure_change_transaction_metadata_tenure_change_payload.go
+++ b/stacks/models/model_tenure_change_transaction_metadata_tenure_change_payload.go
@@ -274,7 +274,6 @@ func (o *TenureChangeTransactionMetadataTenureChangePayload) UnmarshalJSON(data 
 	varTenureChangeTransactionMetadataTenureChangePayload := _TenureChangeTransactionMetadataTenureChangePayload{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTenureChangeTransactionMetadataTenureChangePayload)
 
 	if err != nil {

--- a/stacks/models/model_token_transfer_transaction.go
+++ b/stacks/models/model_token_transfer_transaction.go
@@ -1155,7 +1155,6 @@ func (o *TokenTransferTransaction) UnmarshalJSON(data []byte) (err error) {
 	varTokenTransferTransaction := _TokenTransferTransaction{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTokenTransferTransaction)
 
 	if err != nil {

--- a/stacks/models/model_token_transfer_transaction_metadata_token_transfer.go
+++ b/stacks/models/model_token_transfer_transaction_metadata_token_transfer.go
@@ -157,7 +157,6 @@ func (o *TokenTransferTransactionMetadataTokenTransfer) UnmarshalJSON(data []byt
 	varTokenTransferTransactionMetadataTokenTransfer := _TokenTransferTransactionMetadataTokenTransfer{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTokenTransferTransactionMetadataTokenTransfer)
 
 	if err != nil {

--- a/stacks/models/model_transaction_event_fungible_asset.go
+++ b/stacks/models/model_transaction_event_fungible_asset.go
@@ -183,7 +183,6 @@ func (o *TransactionEventFungibleAsset) UnmarshalJSON(data []byte) (err error) {
 	varTransactionEventFungibleAsset := _TransactionEventFungibleAsset{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionEventFungibleAsset)
 
 	if err != nil {

--- a/stacks/models/model_transaction_event_fungible_asset_all_of_asset.go
+++ b/stacks/models/model_transaction_event_fungible_asset_all_of_asset.go
@@ -211,7 +211,6 @@ func (o *TransactionEventFungibleAssetAllOfAsset) UnmarshalJSON(data []byte) (er
 	varTransactionEventFungibleAssetAllOfAsset := _TransactionEventFungibleAssetAllOfAsset{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionEventFungibleAssetAllOfAsset)
 
 	if err != nil {

--- a/stacks/models/model_transaction_event_non_fungible_asset.go
+++ b/stacks/models/model_transaction_event_non_fungible_asset.go
@@ -183,7 +183,6 @@ func (o *TransactionEventNonFungibleAsset) UnmarshalJSON(data []byte) (err error
 	varTransactionEventNonFungibleAsset := _TransactionEventNonFungibleAsset{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionEventNonFungibleAsset)
 
 	if err != nil {

--- a/stacks/models/model_transaction_event_non_fungible_asset_all_of_asset.go
+++ b/stacks/models/model_transaction_event_non_fungible_asset_all_of_asset.go
@@ -211,7 +211,6 @@ func (o *TransactionEventNonFungibleAssetAllOfAsset) UnmarshalJSON(data []byte) 
 	varTransactionEventNonFungibleAssetAllOfAsset := _TransactionEventNonFungibleAssetAllOfAsset{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionEventNonFungibleAssetAllOfAsset)
 
 	if err != nil {

--- a/stacks/models/model_transaction_event_smart_contract_log.go
+++ b/stacks/models/model_transaction_event_smart_contract_log.go
@@ -183,7 +183,6 @@ func (o *TransactionEventSmartContractLog) UnmarshalJSON(data []byte) (err error
 	varTransactionEventSmartContractLog := _TransactionEventSmartContractLog{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionEventSmartContractLog)
 
 	if err != nil {

--- a/stacks/models/model_transaction_event_smart_contract_log_all_of_contract_log.go
+++ b/stacks/models/model_transaction_event_smart_contract_log_all_of_contract_log.go
@@ -155,7 +155,6 @@ func (o *TransactionEventSmartContractLogAllOfContractLog) UnmarshalJSON(data []
 	varTransactionEventSmartContractLogAllOfContractLog := _TransactionEventSmartContractLogAllOfContractLog{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionEventSmartContractLogAllOfContractLog)
 
 	if err != nil {

--- a/stacks/models/model_transaction_event_stx_asset.go
+++ b/stacks/models/model_transaction_event_stx_asset.go
@@ -183,7 +183,6 @@ func (o *TransactionEventStxAsset) UnmarshalJSON(data []byte) (err error) {
 	varTransactionEventStxAsset := _TransactionEventStxAsset{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionEventStxAsset)
 
 	if err != nil {

--- a/stacks/models/model_transaction_event_stx_lock.go
+++ b/stacks/models/model_transaction_event_stx_lock.go
@@ -183,7 +183,6 @@ func (o *TransactionEventStxLock) UnmarshalJSON(data []byte) (err error) {
 	varTransactionEventStxLock := _TransactionEventStxLock{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionEventStxLock)
 
 	if err != nil {

--- a/stacks/models/model_transaction_event_stx_lock_all_of_stx_lock_event.go
+++ b/stacks/models/model_transaction_event_stx_lock_all_of_stx_lock_event.go
@@ -155,7 +155,6 @@ func (o *TransactionEventStxLockAllOfStxLockEvent) UnmarshalJSON(data []byte) (e
 	varTransactionEventStxLockAllOfStxLockEvent := _TransactionEventStxLockAllOfStxLockEvent{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionEventStxLockAllOfStxLockEvent)
 
 	if err != nil {

--- a/stacks/models/model_transaction_events_response.go
+++ b/stacks/models/model_transaction_events_response.go
@@ -155,7 +155,6 @@ func (o *TransactionEventsResponse) UnmarshalJSON(data []byte) (err error) {
 	varTransactionEventsResponse := _TransactionEventsResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionEventsResponse)
 
 	if err != nil {

--- a/stacks/models/model_transaction_fee_estimate_request.go
+++ b/stacks/models/model_transaction_fee_estimate_request.go
@@ -135,7 +135,6 @@ func (o *TransactionFeeEstimateRequest) UnmarshalJSON(data []byte) (err error) {
 	varTransactionFeeEstimateRequest := _TransactionFeeEstimateRequest{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionFeeEstimateRequest)
 
 	if err != nil {

--- a/stacks/models/model_transaction_fee_estimate_response.go
+++ b/stacks/models/model_transaction_fee_estimate_response.go
@@ -199,7 +199,6 @@ func (o *TransactionFeeEstimateResponse) UnmarshalJSON(data []byte) (err error) 
 	varTransactionFeeEstimateResponse := _TransactionFeeEstimateResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionFeeEstimateResponse)
 
 	if err != nil {

--- a/stacks/models/model_transaction_fee_estimate_response_estimated_cost.go
+++ b/stacks/models/model_transaction_fee_estimate_response_estimated_cost.go
@@ -211,7 +211,6 @@ func (o *TransactionFeeEstimateResponseEstimatedCost) UnmarshalJSON(data []byte)
 	varTransactionFeeEstimateResponseEstimatedCost := _TransactionFeeEstimateResponseEstimatedCost{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionFeeEstimateResponseEstimatedCost)
 
 	if err != nil {

--- a/stacks/models/model_transaction_found.go
+++ b/stacks/models/model_transaction_found.go
@@ -127,7 +127,6 @@ func (o *TransactionFound) UnmarshalJSON(data []byte) (err error) {
 	varTransactionFound := _TransactionFound{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionFound)
 
 	if err != nil {

--- a/stacks/models/model_transaction_identifier.go
+++ b/stacks/models/model_transaction_identifier.go
@@ -100,7 +100,6 @@ func (o *TransactionIdentifier) UnmarshalJSON(data []byte) (err error) {
 	varTransactionIdentifier := _TransactionIdentifier{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionIdentifier)
 
 	if err != nil {

--- a/stacks/models/model_transaction_not_found.go
+++ b/stacks/models/model_transaction_not_found.go
@@ -127,7 +127,6 @@ func (o *TransactionNotFound) UnmarshalJSON(data []byte) (err error) {
 	varTransactionNotFound := _TransactionNotFound{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionNotFound)
 
 	if err != nil {

--- a/stacks/models/model_transaction_not_found_result.go
+++ b/stacks/models/model_transaction_not_found_result.go
@@ -99,7 +99,6 @@ func (o *TransactionNotFoundResult) UnmarshalJSON(data []byte) (err error) {
 	varTransactionNotFoundResult := _TransactionNotFoundResult{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionNotFoundResult)
 
 	if err != nil {

--- a/stacks/models/model_transaction_results.go
+++ b/stacks/models/model_transaction_results.go
@@ -186,7 +186,6 @@ func (o *TransactionResults) UnmarshalJSON(data []byte) (err error) {
 	varTransactionResults := _TransactionResults{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTransactionResults)
 
 	if err != nil {

--- a/stacks/models/model_tx_search_result.go
+++ b/stacks/models/model_tx_search_result.go
@@ -130,7 +130,6 @@ func (o *TxSearchResult) UnmarshalJSON(data []byte) (err error) {
 	varTxSearchResult := _TxSearchResult{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTxSearchResult)
 
 	if err != nil {

--- a/stacks/models/model_tx_search_result_result.go
+++ b/stacks/models/model_tx_search_result_result.go
@@ -192,7 +192,6 @@ func (o *TxSearchResultResult) UnmarshalJSON(data []byte) (err error) {
 	varTxSearchResultResult := _TxSearchResultResult{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTxSearchResultResult)
 
 	if err != nil {

--- a/stacks/models/model_tx_search_result_result_tx_data.go
+++ b/stacks/models/model_tx_search_result_result_tx_data.go
@@ -213,7 +213,6 @@ func (o *TxSearchResultResultTxData) UnmarshalJSON(data []byte) (err error) {
 	varTxSearchResultResultTxData := _TxSearchResultResultTxData{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varTxSearchResultResultTxData)
 
 	if err != nil {

--- a/stacks/models/model_unanchored_transaction_list_response.go
+++ b/stacks/models/model_unanchored_transaction_list_response.go
@@ -128,7 +128,6 @@ func (o *UnanchoredTransactionListResponse) UnmarshalJSON(data []byte) (err erro
 	varUnanchoredTransactionListResponse := _UnanchoredTransactionListResponse{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
 	err = decoder.Decode(&varUnanchoredTransactionListResponse)
 
 	if err != nil {


### PR DESCRIPTION
## Summary

- Remove `DisallowUnknownFields()` from all 220 model `UnmarshalJSON` methods (not just mempool models)
- Makes deserialization resilient to Stacks API schema additions

## Context

The Stacks API can return fields not present in the SDK's generated struct definitions. For example, dropped transactions include `replaced_by_tx_id` which isn't in any mempool transaction model. `DisallowUnknownFields()` causes the JSON decoder to reject these valid responses entirely.

This breaks `DoesTransactionExist` in the arnac retransmit task — producing ~5,000 errors/week in production. The `anyOf` union in `GetTransactionById200Response` tries both the confirmed and mempool transaction branches, both fail due to unknown fields, and the caller gets an error instead of a successful parse.

Same category of issue as #4 (c88623b) where strict schema validation rejected valid API responses. Since this is a generated SDK and the Stacks API evolves independently, strict unknown field rejection is counterproductive across all models.

## Not a breaking change

Only removes a restriction. Any code that was successfully deserializing before will continue to work identically.